### PR TITLE
Support for hot reloading Chrome extension

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
   parserOptions: {
-       "ecmaVersion": 6
+    "ecmaVersion": 6
   },
   plugins: [
     '@typescript-eslint',
@@ -14,10 +14,13 @@ module.exports = {
   ],
   env: {
     "amd": true,
-    "node": true  
+    "node": true,
+    "es6": true,
+    "webextensions": true
   },
   rules: {
     "@typescript-eslint/no-use-before-define": "off",
-    "@typescript-eslint/explicit-function-return-type": "off"
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-var-requires": "off"
   }
 };

--- a/README.md
+++ b/README.md
@@ -15,4 +15,15 @@ npm install
 npm run [chrome, firefox]
 ```
 
+## Development (Chrome)
+
+``` bash
+# install development dependencies
+npm install 
+# compiles the chrome extension to the `./chrome` directory and watches for file changes
+npm run dev:chrome
+```
+
+Load the unpacked extension and when files in `./src` are changed, the extension will reload
+
 Note that Windows users should download a tool like [Git Bash](https://git-scm.com/download/win) or [Cygwin](http://cygwin.com/) to build.

--- a/hot-reload.js
+++ b/hot-reload.js
@@ -1,0 +1,36 @@
+const filesInDirectory = dir => new Promise (resolve =>
+    dir.createReader ().readEntries (entries =>
+        Promise.all (entries.filter (e => e.name[0] !== '.').map (e =>
+            e.isDirectory
+                ? filesInDirectory (e)
+                : new Promise (resolve => e.file (resolve))
+        ))
+            .then (files => [].concat (...files))
+            .then (resolve)
+    )
+)
+
+const timestampForFilesInDirectory = dir =>
+    filesInDirectory (dir).then (files =>
+        files.map (f => f.name + f.lastModifiedDate).join ())
+
+const watchChanges = (dir, lastTimestamp) => {
+    timestampForFilesInDirectory (dir).then (timestamp => {
+        if (!lastTimestamp || (lastTimestamp === timestamp)) {
+            setTimeout (() => watchChanges (dir, timestamp), 1000) // retry after 1s
+        } else {
+            chrome.runtime.reload ()
+        }
+    })
+}
+
+chrome.management.getSelf (self => {
+    if (self.installType === 'development') {
+        chrome.runtime.getPackageDirectoryEntry (dir => watchChanges (dir))
+        chrome.tabs.query ({ active: true, lastFocusedWindow: true }, tabs => { // NB: see https://github.com/xpl/crx-hotreload/issues/5
+            if (tabs[0]) {
+                chrome.tabs.reload (tabs[0].id)
+            }
+        })
+    }
+})

--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -39,7 +39,8 @@
     },
     "background": {
         "scripts": [
-            "dist/background.js"
+            "dist/background.js",
+            "hot-reload.js"
         ],
         "persistent": true
     },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Authenticator generates 2-Step Verification codes in your browser.",
   "scripts": {
     "compile": "bash ./scripts/build.sh firefox",
+    "dev:chrome": "npm run chrome && node ./node_modules/webpack-cli/bin/cli.js --config webpack.dev.js",
     "fix": "gts fix",
     "chrome": "bash scripts/build.sh chrome",
     "firefox": "bash scripts/build.sh firefox",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -73,6 +73,7 @@ postCompile () {
     cp manifest-$1.json $1/manifest.json
     if [[ $1 = "chrome" ]]; then
         cp schema-chrome.json $1/schema.json
+        cp hot-reload.js $1/hot-reload.js
     fi
 }
 

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,0 +1,15 @@
+const path = require("path");
+const merge = require("webpack-merge");
+const common = require("./webpack.config.js");
+
+module.exports = merge(common, {
+    watch: true,
+    watchOptions: {
+        ignored: /node_modules/
+    },
+    // dev mode currently only for chrome
+    output: {
+        path: path.resolve(__dirname, "chrome/dist"),
+        publicPath: "/chrome/dist/"
+    }
+});


### PR DESCRIPTION
By running `npm run dev:chrome`, hot reloading the extension occurs
when one of the `./src` files is changed.  Allows for quicker
development